### PR TITLE
Major visual novel spoilers shouldn't show in embeds.

### DIFF
--- a/extensions/adata.py
+++ b/extensions/adata.py
@@ -1379,7 +1379,7 @@ async def _search_vn(ctx: lb.Context, query: str):
             for tag in sorted(
                 req["results"][0]["tags"], key=itemgetter("rating"), reverse=True
             ):
-                if tag["category"] == "cont" and tag["spoiler"] == 0: # spoiler returns an int, 0 being not a spoiler, 1 being minor spoiler, 2 being major.
+                if tag["category"] == "cont" and tag["spoiler"] != 2: # spoiler returns an int, 0 being not a spoiler, 1 being minor spoiler, 2 being major.
                     tags.append(tag["name"])
 
                 if len(tags) == 7:

--- a/extensions/adata.py
+++ b/extensions/adata.py
@@ -1379,7 +1379,7 @@ async def _search_vn(ctx: lb.Context, query: str):
             for tag in sorted(
                 req["results"][0]["tags"], key=itemgetter("rating"), reverse=True
             ):
-                if tag["category"] == "cont" and tag["spoiler"] == False:
+                if tag["category"] == "cont" and tag["spoiler"] == 0: # spoiler returns an int, 0 being not a spoiler, 1 being minor spoiler, 2 being major.
                     tags.append(tag["name"])
 
                 if len(tags) == 7:

--- a/extensions/adata.py
+++ b/extensions/adata.py
@@ -1379,10 +1379,8 @@ async def _search_vn(ctx: lb.Context, query: str):
             for tag in sorted(
                 req["results"][0]["tags"], key=itemgetter("rating"), reverse=True
             ):
-                if tag["category"] == "cont":
-                    tags.append(
-                        tag["name"] if not tag["spoiler"] else f"||{tag['name']}||"
-                    )
+                if tag["category"] == "cont" and tag["spoiler"] == False:
+                    tags.append(tag["name"])
 
                 if len(tags) == 7:
                     break

--- a/extensions/adata.py
+++ b/extensions/adata.py
@@ -1380,7 +1380,9 @@ async def _search_vn(ctx: lb.Context, query: str):
                 req["results"][0]["tags"], key=itemgetter("rating"), reverse=True
             ):
                 if tag["category"] == "cont" and tag["spoiler"] != 2: # spoiler returns an int, 0 being not a spoiler, 1 being minor spoiler, 2 being major.
-                    tags.append(tag["name"])
+                    tags.append(
+                        tag["name"] if not tag["spoiler"] else f"||{tag['name']}||"
+                    )
 
                 if len(tags) == 7:
                     break


### PR DESCRIPTION
Spoilers being in the embed makes it way too easy to spoil yourself on a novel. The entire point of this command is to show people who are not aware of the novel what the novel is, and including spoilers within that seems dumb. VNDB has a good implementation where it doesn't even show that the spoiler tags exist unless you click "Spoil me!", and Anilist does something similar. I believe AkaneBot should do the same.

before and after:
![image](https://github.com/user-attachments/assets/3c1c3479-37bb-4b1e-978e-dd1f535a5c91)

:shipit: 